### PR TITLE
Check for $info_message to avoid notices

### DIFF
--- a/woocommerce-dynamic-pricing-table.php
+++ b/woocommerce-dynamic-pricing-table.php
@@ -352,9 +352,9 @@ final class WC_Dynamic_Pricing_Table {
       }
 
     }
-
-    wc_add_notice( $info_message, 'notice' );
-
+    if(isset($info_message)) {
+      wc_add_notice( $info_message, 'notice' );
+    }
   }
 
   /**
@@ -402,9 +402,9 @@ final class WC_Dynamic_Pricing_Table {
       }
 
     }
-
-    wc_add_notice( $info_message, 'notice' );
-
+    if(isset($info_message)) {
+      wc_add_notice( $info_message, 'notice' );
+    }
   }
 
   /**


### PR DESCRIPTION
Added isset() check around the 2 calls to wc_add_notice for info_message to avoid PHP notice: undefined variable in error logs.